### PR TITLE
bump actionlint version from 1.6.26 to 1.6.27

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: actionlint
         name: Lint Github workflows
         language: docker_image
-        entry: rhysd/actionlint:1.6.26
+        entry: rhysd/actionlint:1.6.27
         files: ^\.github/workflows/.*\.yml$
 
       - id: hadolint

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,7 +8,7 @@
 - id: actionlint
   name: Lint Github workflows
   language: docker_image
-  entry: rhysd/actionlint:1.6.26
+  entry: rhysd/actionlint:1.6.27
   files: ^\.github/workflows/.*\.yml$
 
 - id: hadolint


### PR DESCRIPTION
[Since version 1.6.27](https://github.com/rhysd/actionlint/blob/main/CHANGELOG.md#v1627---24-feb-2024) `actionlint` supports some new types for the `pull_request` event. I will need one of this, `dequeued`.

This PR aims to update `actionlint`. I have not found any other places where versions were present in the repository, but I might have missed something