### PR TITLE
Allow yaml files as well when linting actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         name: Lint Github workflows
         language: docker_image
         entry: rhysd/actionlint:1.7.7
-        files: ^\.github/workflows/.*\.yml$
+        files: ^\.github/workflows/.*\.(yml|yaml)$
 
       - id: hadolint
         name: Lint Dockerfiles

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,7 +9,7 @@
   name: Lint Github workflows
   language: docker_image
   entry: rhysd/actionlint:1.7.7
-  files: ^\.github/workflows/.*\.yml$
+  files: ^\.github/workflows/.*\.(yml|yaml)$
 
 - id: hadolint
   name: Lint Dockerfiles


### PR DESCRIPTION
Allow YAML files (not just YML) when linting github actions.

