### PR TITLE
Fix hadolint CI error

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,5 +14,5 @@
 - id: hadolint
   name: Lint Dockerfiles
   language: docker_image
-  entry: hadolint/hadolint hadolint
+  entry: hadolint/hadolint:latest-alpine hadolint
   files: Dockerfile

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,5 +14,5 @@
 - id: hadolint
   name: Lint Dockerfiles
   language: docker_image
-  entry: hadolint/hadolint:latest-alpine hadolint
+  entry: hadolint/hadolint:v2.12.1-beta-debian hadolint
   files: Dockerfile


### PR DESCRIPTION
Right now the CI is broken because of hadolint, I use the old version for now.

I think long term we should use the binary directly as this docker looks not well maintained (last update now and the one before two years ago).

https://pennylane-org.slack.com/archives/C02FA990G3E/p1752579677839739