### PR TITLE
Fix ltex Docker image loading with buildx docker-container driver

### DIFF
--- a/ltex/ltex.sh
+++ b/ltex/ltex.sh
@@ -12,7 +12,7 @@ ltex_version="ltex:$ltex_tag"
 
 (
   cd "$ltex_dir"
-  docker inspect "$ltex_version" &>/dev/null || docker build . -t "$ltex_version" -t 'ltex:latest' > /dev/null
+  docker inspect "$ltex_version" &>/dev/null || docker build --load . -t "$ltex_version" -t 'ltex:latest' > /dev/null
 )
 
 files_to_clean=()


### PR DESCRIPTION
## Problem

The ltex pre-commit hook fails when using Podman Desktop or Docker setups with the `docker-container` buildx driver. 

When the buildx driver is set to `docker-container`, the `docker build` command is aliased to `docker buildx build`, which has different behavior:
- **Without `--load`**: Images are built and stored only in the BuildKit cache, not in the local Docker image store
- **With `--load`**: Images are built and explicitly exported to the local Docker image store

This causes the hook to fail with "Unable to find image" errors even though the build succeeds.

```
jeancaisse (master) ❯ pre-commit run ltex --files app/javascript/documentation/ui/InputGroup.mdx
LTeX grammar check.......................................................Passed
- hook id: ltex
- duration: 20.02s

[+] Building 17.8s (7/7) FINISHED                       docker-container:podman
 => [internal] booting buildkit                                            2.4s
 => => pulling image moby/buildkit:buildx-stable-1                         1.9s
 => => creating container buildx_buildkit_podman                           0.5s
 => [internal] load build definition from Dockerfile                       0.0s
 => => transferring dockerfile: 356B                                       0.0s
 => [internal] load metadata for docker.io/library/openjdk:11.0.16-jre     1.8s
 => [auth] library/openjdk:pull token for registry-1.docker.io             0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [1/2] FROM docker.io/library/openjdk:11.0.16-jre@sha256:356949c3125c4  4.3s
 => => resolve docker.io/library/openjdk:11.0.16-jre@sha256:356949c3125c4  0.0s
 => => sha256:40af590bb61e926debbe8ba325fa28ee651fec79c 45.07MB / 45.07MB  1.3s
 => => sha256:f3b7f28ea2855580a872ab6a4242d40e22c12ccc031 5.65MB / 5.65MB  3.2s
 => => sha256:3d45ceb6cdd310b5a38d1e452968a59edcea4296d763533 213B / 213B  0.7s
 => => sha256:a4ea641ee67989acdb6af3d8b9b984ecd751a2a83 10.66MB / 10.66MB  3.5s
 => => sha256:bc0b8a8acead4d7bf71c232054b2a0a8e08eb3e1e2c 5.15MB / 5.15MB  2.5s
 => => sha256:114ba63dd73a866ac1bb59fe594dfd218f44ac9b4 53.68MB / 53.68MB  1.7s
 => => extracting sha256:114ba63dd73a866ac1bb59fe594dfd218f44ac9b4fa4b2c6  0.7s
 => => extracting sha256:bc0b8a8acead4d7bf71c232054b2a0a8e08eb3e1e2cf46f9  0.1s
 => => extracting sha256:a4ea641ee67989acdb6af3d8b9b984ecd751a2a83c3b7ce0  0.1s
 => => extracting sha256:f3b7f28ea2855580a872ab6a4242d40e22c12ccc0312535a  0.1s
 => => extracting sha256:3d45ceb6cdd310b5a38d1e452968a59edcea4296d7635339  0.0s
 => => extracting sha256:40af590bb61e926debbe8ba325fa28ee651fec79c1161422  0.4s
 => [2/2] RUN <<EOF (wget --quiet https://github.com/valentjn/ltex-ls/rel  9.0s
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
Unable to find image 'ltex:fab384d395d14a01625469c353001216' locally
docker: Error response from daemon: {"message":"denied: requested access to the resource is denied"}

Run 'docker run --help' for more information
```

https://pennylane-org.slack.com/archives/C02FA990G3E/p1763743765413389

## Solution

Add the `--load` flag to the `docker build` command in `ltex/ltex.sh` to ensure compatibility with both:
- Standard Docker Desktop (with default `docker` driver) - `--load` is a no-op
- Podman Desktop and docker-container driver setups - `--load` exports the image correctly