### PR TITLE
Bump actionlint to 1.7.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: actionlint
         name: Lint Github workflows
         language: docker_image
-        entry: rhysd/actionlint:1.7.7
+        entry: rhysd/actionlint:1.7.12
         files: ^\.github/workflows/.*\.(yml|yaml)$
 
       - id: hadolint

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,7 +8,7 @@
 - id: actionlint
   name: Lint Github workflows
   language: docker_image
-  entry: rhysd/actionlint:1.7.7
+  entry: rhysd/actionlint:1.7.12
   files: ^\.github/workflows/.*\.(yml|yaml)$
 
 - id: hadolint


### PR DESCRIPTION
Bump actionlint to 1.7.12 to support timezones in cron schedules.